### PR TITLE
Adds support for matching warnings

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -18,12 +18,14 @@ pub(crate) enum Error {
     Pattern(PatternError),
     ProjectDir,
     ReadStderr(io::Error),
+    ReadWarn(io::Error),
     RunFailed,
     ShouldNotHaveCompiled,
     TomlDe(toml::de::Error),
     TomlSer(toml::ser::Error),
     UpdateVar(OsString),
     WriteStderr(io::Error),
+    WriteWarn(io::Error),
 }
 
 pub(crate) type Result<T> = std::result::Result<T, Error>;
@@ -57,6 +59,8 @@ impl Display for Error {
                 var.to_string_lossy(),
             ),
             WriteStderr(e) => write!(f, "failed to write stderr file: {}", e),
+            WriteWarn(e) => write!(f, "failed to write warn file: {}", e),
+            ReadWarn(e) => write!(f, "failed to read warn file: {}", e),
         }
     }
 }

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -27,6 +27,7 @@ pub(crate) fn expand_globs(tests: &[Test]) -> Vec<ExpandedTest> {
                                 expected,
                                 envs: test.envs.clone(),
                                 features: test.features.clone(),
+                                check_warnings: test.check_warnings,
                             },
                             None,
                             true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,6 +305,7 @@ struct Test {
     expected: Expected,
     envs: Vec<(OsString, OsString)>,
     features: Vec<OsString>,
+    check_warnings: bool,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -327,6 +328,7 @@ impl TestCases {
             expected: Expected::Pass,
             envs: Vec::new(),
             features: Vec::new(),
+            check_warnings: false,
         });
     }
 
@@ -335,6 +337,7 @@ impl TestCases {
         path: P,
         envs: impl IntoIterator<Item = (impl Into<OsString>, impl Into<OsString>)>,
         features: impl IntoIterator<Item = impl Into<OsString>>,
+        check_warnings: bool,
     ) {
         self.runner.borrow_mut().tests.push(Test {
             path: path.as_ref().to_owned(),
@@ -344,6 +347,7 @@ impl TestCases {
                 .map(|(k, v)| (k.into(), v.into()))
                 .collect(),
             features: features.into_iter().map(|f| f.into()).collect(),
+            check_warnings,
         });
     }
 
@@ -353,6 +357,7 @@ impl TestCases {
             expected: Expected::CompileFail,
             envs: Vec::new(),
             features: Vec::new(),
+            check_warnings: false,
         });
     }
 
@@ -361,6 +366,7 @@ impl TestCases {
         path: P,
         envs: impl IntoIterator<Item = (impl Into<OsString>, impl Into<OsString>)>,
         features: impl IntoIterator<Item = impl Into<OsString>>,
+        check_warnings: bool,
     ) {
         self.runner.borrow_mut().tests.push(Test {
             path: path.as_ref().to_owned(),
@@ -370,6 +376,7 @@ impl TestCases {
                 .map(|(k, v)| (k.into(), v.into()))
                 .collect(),
             features: features.into_iter().map(|f| f.into()).collect(),
+            check_warnings,
         });
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -379,6 +379,17 @@ impl TestCases {
             check_warnings,
         });
     }
+
+    /// Checks if the compilation passes with warnings.
+    pub fn warn<P: AsRef<Path>>(&self, path: P) {
+        self.runner.borrow_mut().tests.push(Test {
+            path: path.as_ref().to_owned(),
+            expected: Expected::Pass,
+            envs: Vec::new(),
+            features: Vec::new(),
+            check_warnings: true,
+        });
+    }
 }
 
 impl RefUnwindSafe for TestCases {}

--- a/src/message.rs
+++ b/src/message.rs
@@ -102,6 +102,21 @@ pub(crate) fn write_stderr_wip(wip_path: &Path, stderr_path: &Path, stderr: &str
     println!();
 }
 
+pub(crate) fn write_warn_wip(wip_path: &Path, warn_path: &Path, warn: &str) {
+    let wip_path = wip_path.to_string_lossy();
+    let warn_path = warn_path.to_string_lossy();
+
+    term::bold_color(Yellow);
+    println!("wip");
+    println!();
+    print!("NOTE");
+    term::reset();
+    println!(": writing the following output to `{}`.", wip_path);
+    println!("Move this file to `{}` to accept it as correct.", warn_path,);
+    snippet(Yellow, warn);
+    println!();
+}
+
 pub(crate) fn overwrite_stderr(stderr_path: &Path, stderr: &str) {
     let stderr_path = stderr_path.to_string_lossy();
 
@@ -112,6 +127,19 @@ pub(crate) fn overwrite_stderr(stderr_path: &Path, stderr: &str) {
     term::reset();
     println!(": writing the following output to `{}`.", stderr_path);
     snippet(Yellow, stderr);
+    println!();
+}
+
+pub(crate) fn overwrite_warn(warn_path: &Path, warn: &str) {
+    let warn_path = warn_path.to_string_lossy();
+
+    term::bold_color(Yellow);
+    println!("wip");
+    println!();
+    print!("NOTE");
+    term::reset();
+    println!(": writing the following output to `{}`.", warn_path);
+    snippet(Yellow, warn);
     println!();
 }
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -33,6 +33,7 @@ pub(crate) struct Project {
     pub path_dependencies: Vec<PathDependency>,
     manifest: Manifest,
     pub keep_going: bool,
+    pub check_warnings: bool,
 }
 
 #[derive(Debug)]
@@ -182,6 +183,7 @@ impl Runner {
             path_dependencies,
             manifest,
             keep_going: false,
+            check_warnings: tests.iter().all(|t| t.test.check_warnings),
         })
     }
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -439,14 +439,16 @@ impl Test {
             return Err(Error::CargoFail);
         }
 
-        let warnings_outcome =
-            self.check_warnings(project, name, success, build_stdout, variations)?;
+        if project.check_warnings {
+            let warnings_outcome =
+                self.check_warnings(project, name, success, build_stdout, variations)?;
 
-        match warnings_outcome {
-            Outcome::Passed => {}
-            Outcome::CreatedWip => {
-                message::fail_output(Warn, build_stdout);
-                return Ok(Outcome::CreatedWip);
+            match warnings_outcome {
+                Outcome::Passed => {}
+                Outcome::CreatedWip => {
+                    message::fail_output(Warn, build_stdout);
+                    return Ok(Outcome::CreatedWip);
+                }
             }
         }
 
@@ -532,7 +534,11 @@ impl Test {
 
         // Byt the same token, we can unwrap the warnings check
         // Further, at this point, the error outcome will be passed--all other branches have terminated.
-        self.check_warnings(project, name, success, build_stdout, variations)
+        if project.check_warnings {
+            self.check_warnings(project, name, success, build_stdout, variations)
+        } else {
+            Ok(Outcome::Passed)
+        }
     }
 
     fn check_warnings(

--- a/src/run.rs
+++ b/src/run.rs
@@ -437,6 +437,17 @@ impl Test {
             return Err(Error::CargoFail);
         }
 
+        let warnings_outcome =
+            self.check_warnings(project, name, success, build_stdout, variations)?;
+
+        match warnings_outcome {
+            Outcome::Passed => {}
+            Outcome::CreatedWip => {
+                message::fail_output(Warn, build_stdout);
+                return Ok(Outcome::CreatedWip);
+            }
+        }
+
         let mut output = cargo::run_test(project, name)?;
         output.stdout.splice(..0, build_stdout.bytes());
         message::output(preferred, &output);
@@ -450,7 +461,7 @@ impl Test {
     fn check_compile_fail(
         &self,
         project: &Project,
-        _name: &Name,
+        name: &Name,
         success: bool,
         build_stdout: &str,
         variations: &Variations,
@@ -466,7 +477,7 @@ impl Test {
 
         let stderr_path = self.path.with_extension("stderr");
 
-        if !stderr_path.exists() {
+        let _error_outcome = if !stderr_path.exists() {
             let outcome = match project.update {
                 Update::Wip => {
                     let wip_dir = Path::new("wip");
@@ -488,14 +499,82 @@ impl Test {
                 }
             };
             message::fail_output(Warn, build_stdout);
+            Ok(outcome)
+        } else {
+            let expected = fs::read_to_string(&stderr_path)
+                .map_err(Error::ReadStderr)?
+                .replace("\r\n", "\n");
+
+            // we unwrap the mismatch because if there is a failure we should short-circuit
+            // overwrites will match for warnings.
+            if variations.any(|stderr| expected == stderr) {
+                message::ok();
+                return Ok(Outcome::Passed);
+            } else {
+                match project.update {
+                    Update::Wip => {
+                        message::mismatch(&expected, preferred);
+                        Err(Error::Mismatch)
+                    }
+                    Update::Overwrite => {
+                        message::overwrite_stderr(&stderr_path, preferred);
+                        fs::write(stderr_path, preferred).map_err(Error::WriteStderr)?;
+                        Ok(Outcome::Passed)
+                    }
+                }
+            }
+        }?;
+
+        // We don't actually need _error_outcome, because project update should match.
+        // And, if the there's a genuine mismatch, we're good to short-circuit
+
+        // Byt the same token, we can unwrap the warnings check
+        // Further, at this point, the error outcome will be passed--all other branches have terminated.
+        self.check_warnings(project, name, success, build_stdout, variations)
+    }
+
+    fn check_warnings(
+        &self,
+        project: &Project,
+        _name: &Name,
+        _success: bool,
+        build_stdout: &str,
+        variations: &Variations,
+    ) -> Result<Outcome> {
+        let preferred = variations.preferred();
+
+        let warn_path = self.path.with_extension("warn");
+
+        if !warn_path.exists() {
+            let outcome = match project.update {
+                Update::Wip => {
+                    let wip_dir = Path::new("wip");
+                    fs::create_dir_all(wip_dir)?;
+                    let gitignore_path = wip_dir.join(".gitignore");
+                    fs::write(gitignore_path, "*\n")?;
+                    let warn_name = warn_path
+                        .file_name()
+                        .unwrap_or_else(|| OsStr::new("test.warn"));
+                    let wip_path = wip_dir.join(warn_name);
+                    message::write_warn_wip(&wip_path, &warn_path, preferred);
+                    fs::write(wip_path, preferred).map_err(Error::WriteWarn)?;
+                    Outcome::CreatedWip
+                }
+                Update::Overwrite => {
+                    message::overwrite_warn(&warn_path, preferred);
+                    fs::write(warn_path, preferred).map_err(Error::WriteWarn)?;
+                    Outcome::Passed
+                }
+            };
+            message::fail_output(Warn, build_stdout);
             return Ok(outcome);
         }
 
-        let expected = fs::read_to_string(&stderr_path)
-            .map_err(Error::ReadStderr)?
+        let expected = fs::read_to_string(&warn_path)
+            .map_err(Error::ReadWarn)?
             .replace("\r\n", "\n");
 
-        if variations.any(|stderr| expected == stderr) {
+        if variations.any(|warn| expected == warn) {
             message::ok();
             return Ok(Outcome::Passed);
         }
@@ -506,8 +585,8 @@ impl Test {
                 Err(Error::Mismatch)
             }
             Update::Overwrite => {
-                message::overwrite_stderr(&stderr_path, preferred);
-                fs::write(stderr_path, preferred).map_err(Error::WriteStderr)?;
+                message::overwrite_warn(&warn_path, preferred);
+                fs::write(warn_path, preferred).map_err(Error::WriteWarn)?;
                 Ok(Outcome::Passed)
             }
         }


### PR DESCRIPTION
# Summary
Adds support for matching warnings. Includes the overwrite and WIP features used with error. 